### PR TITLE
Extract Probes lib to library

### DIFF
--- a/lib/liveness_plug.ex
+++ b/lib/liveness_plug.ex
@@ -1,0 +1,63 @@
+defmodule ElixirProbes.Plug.LivenessPlug do
+  @moduledoc """
+  Provides a `Plug`-based liveness probe for Kubernetes, responding quickly with
+  a 200 OK.
+
+  This design lightly exercises the Cowboy/Plug stack and the viability of
+  application-level supervision trees, and not much else. Application-specific
+  behavior such as data-store connections should rarely be exercised here,
+  preferring to be included in a readiness probe instead. As this endpoint will
+  be called **once per Pod**, it is imperative that it responds as fast as
+  possible, and preferable that it does not emit logs. We intentionally mount
+  the Plug early in the Endpoint module rather than adding it to a Router,
+  bypassing most of the defined Plugs and Plug pipelines.
+
+  This Plug should typically only return a non-200 response when external
+  intervention is required, such as restarting the BEAM. Ephemeral failure modes
+  that will likely resolve on their own with time and patience should not
+  trigger liveness-probe failures, as a sufficient number of them in a short
+  time will cause Kubernetes to restart the container altogether.
+
+  As we may not assume that this route is only available behind the load
+  balancer, we should take care not to expose internal implementation details or
+  personal information in the response body.
+
+  References:
+  - [Configure Liveness, Readiness and Startup Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+  - [Kubernetes Liveness and Readiness Probes: How to Avoid Shooting Yourself in the Foot](https://blog.colinbreck.com/kubernetes-liveness-and-readiness-probes-how-to-avoid-shooting-yourself-in-the-foot/)
+  - [Health checks for Plug and Phoenix](https://blog.jola.dev/health-checks-for-plug-and-phoenix)
+
+  # Examples
+
+  ```elixir
+    plug ElixirProbes.Plug.LivenessPlug
+  ```
+
+  The matched path can be configured at compile-time using `Mix.Config`:
+
+  ```elixir
+  config :elixir_probes,
+    liveness_path: "/livez"
+  ```
+  """
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @path Application.compile_env(:elixir_probes, :liveness_path, "/probes/liveness")
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{method: "GET", request_path: @path} = conn, _opts) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(200, "alive: #{:erlang.system_time(:second)}")
+    |> halt()
+  end
+
+  def call(conn, _opts), do: conn
+
+  @doc "Returns the configured `request_path` for this Plug"
+  @spec path :: String.t()
+  def path, do: @path
+end

--- a/lib/readiness_checks.ex
+++ b/lib/readiness_checks.ex
@@ -1,0 +1,17 @@
+defmodule ElixirProbes.ReadinessChecks do
+  @moduledoc """
+  Provides a bag of functions that are given to the ReadinessPlug in order
+  to validate that the app is ready to receive requests.
+  """
+
+  def database_alive?(repo) do
+    match?(
+      {:ok, _},
+      repo.query("SELECT 42", [], timeout: 500)
+    )
+  end
+
+  def elasticsearch_alive_and_indexed?(es_cluster) do
+    es_cluster.ready?()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,21 @@
 defmodule ElixirProbes.MixProject do
   use Mix.Project
 
+  @name "ElixirProbes"
+  @version "0.1.0"
+  @source_url "https://github.com/carsdotcom/elixir_probes"
+
   def project do
     [
       app: :elixir_probes,
-      version: "0.1.0",
-      elixir: "~> 1.17",
+      deps: deps(),
+      description: description(),
+      elixir: "~> 1.14",
+      name: @name,
+      package: package(),
+      source_url: @source_url,
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      version: @version
     ]
   end
 
@@ -22,8 +30,18 @@ defmodule ElixirProbes.MixProject do
   defp deps do
     [
       {:plug, "~> 1.0"}
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+
+  defp description do
+    "Common probes for Elixir applications in Kubernetes deployments"
+  end
+
+  defp package do
+    [
+      name: "pacer",
+      licenses: ["Apache-2.0"],
+      links: %{"GitHub" => @source_url}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule ElixirProbes.MixProject do
 
   defp package do
     [
-      name: "pacer",
+      name: "elixir_probes",
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => @source_url}
     ]

--- a/test/liveness_plug_test.exs
+++ b/test/liveness_plug_test.exs
@@ -1,0 +1,73 @@
+defmodule ElixirProbes.Plug.LivenessPlugTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias ElixirProbes.Plug.LivenessPlug
+
+  @path Application.compile_env(:elixir_probes, :liveness_path, "/probes/liveness")
+
+  setup do
+    {:ok, opts: []}
+  end
+
+  describe "init/1" do
+    test "returns opts unchanged" do
+      opts = [foo: :bar, baz: :qux]
+      assert LivenessPlug.init(opts) == opts
+    end
+  end
+
+  describe "call/2 on matching request path" do
+    setup do
+      {:ok, conn: conn(:get, @path)}
+    end
+
+    test "responds 200 OK", %{conn: conn, opts: opts} do
+      conn = LivenessPlug.call(conn, opts)
+
+      assert {200, _headers, _body} = sent_resp(conn)
+    end
+
+    test "sets a content-type header", %{conn: conn, opts: opts} do
+      conn = LivenessPlug.call(conn, opts)
+
+      assert {_status, headers, _body} = sent_resp(conn)
+      assert {"content-type", "text/plain; charset=utf-8"} in headers
+    end
+
+    test "includes epoch time", %{conn: conn, opts: opts} do
+      timestamp = :erlang.system_time(:second)
+      conn = LivenessPlug.call(conn, opts)
+
+      assert {_status, _headers, "alive: " <> response_timestamp_string} = sent_resp(conn)
+      assert {response_timestamp, ""} = Integer.parse(response_timestamp_string)
+      assert_in_delta timestamp, response_timestamp, 1
+    end
+
+    test "halts the connection", %{conn: conn, opts: opts} do
+      assert %Plug.Conn{halted: true} = LivenessPlug.call(conn, opts)
+    end
+  end
+
+  describe "call/2" do
+    test "passes unmatched request paths through unchanged", %{opts: opts} do
+      conn = conn(:get, "/")
+
+      refute conn.halted
+      assert LivenessPlug.call(conn, opts) == conn
+    end
+
+    test "passes unmatched method through unchanged", %{opts: opts} do
+      conn = conn(:post, @path)
+
+      refute conn.halted
+      assert LivenessPlug.call(conn, opts) == conn
+    end
+  end
+
+  describe "path/0" do
+    test "returns the configured request path for probe" do
+      assert LivenessPlug.path() == @path
+    end
+  end
+end


### PR DESCRIPTION
This extracts a subset of the probes functionality from Cars Marketplace platform into its own standalone repo.

The idea here is that we can pull this in on new Elixir projects to more or less get basic probe behavior for free without needing to copy-paste the same couple modules all over the place.